### PR TITLE
FLPATH-621: assessment precheck

### DIFF
--- a/assessment/README.md
+++ b/assessment/README.md
@@ -12,6 +12,9 @@ In this example, the assessment flow consists of:
   - check whether the repositoryUrl is a java project or not and return workflow options
     - _For simplicity's sake, the java project check is simulated by verifying the presence of the keyword `java` in the repositoryUrl_
   - print workflow options grouped into six categories (current version, upgrade options, migrate options, new options, continuation options, other options) to the user
+- **PreCheck**
+  - validate whether the workflows in the returned assessment options exist
+  - if there are non-existed workflows in the options, then remove them from the options and output the remaining valid ones
 - **End**
 
 **Note**:

--- a/assessment/pom.xml
+++ b/assessment/pom.xml
@@ -32,7 +32,7 @@
         <version>${kogito.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
-     </dependency>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -63,6 +63,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-data-index-inmemory</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/assessment/src/main/resources/application.properties
+++ b/assessment/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+%dev.quarkus.rest-client.dataindex_yaml.url=${kogito.data-index.url:http://localhost:8080}
+quarkus.rest-client.dataindex_yaml.url=${kogito.data-index.url:${DATA_INDEX_SERVICE}}

--- a/assessment/src/main/resources/assessment.sw.yaml
+++ b/assessment/src/main/resources/assessment.sw.yaml
@@ -6,9 +6,6 @@ annotations:
 version: 0.0.1
 start: AssessRepository
 dataInputSchema: schema/input-schema.json
-extensions:
-  - extensionid: workflow-output-schema
-    outputSchema: schema/workflow-options-output-schema.json
 functions:
   - name: execute
     type: custom
@@ -20,7 +17,7 @@ states:
   - name: AssessRepository
     type: operation
     stateDataFilter:
-      output: '{workflowOptions: .result}'
+      output: '{workflowOptions: .validatedResult}'
     actions:
       - name: executeAction
         functionRef:
@@ -29,9 +26,13 @@ states:
             repositoryUrl: ".repositoryUrl"
         actionDataFilter:
           toStateData: ".result"
+      - name: preCheck
+        subFlowRef:
+          workflowId: preCheck
+          version: 0.0.1
       - name: printAction
         functionRef:
           refName: logOuput
           arguments:
-            message: ".workflowOptions"
+            message: ".validatedResult"
     end: true

--- a/assessment/src/main/resources/precheck.sw.yaml
+++ b/assessment/src/main/resources/precheck.sw.yaml
@@ -1,0 +1,79 @@
+specVersion: "0.8"
+id: preCheck
+name: PreCheck
+version: 0.0.1
+start: ExtractWorkflows
+functions:
+  - name: logOuput
+    type: custom
+    operation: "sysout:ERROR"
+  - name: extract
+    type: expression
+    operation: ".result | flatten | map(.id)"
+  - name: checkProcessDefinitionExistence
+    operation: specs/dataindex.yaml#reactiveGraphQLHandlerPost
+  - name: removeMissingWorkflowsFromOptions
+    type: expression
+    operation: '.missingWorkflows as $f | .result | walk( if type == "object" then select(all($f[] != .id; .)) else . end )'
+states:
+  - name: ExtractWorkflows
+    type: operation
+    actions:
+      - name: ExtractWorkflowsAction
+        functionRef:
+          refName: extract
+        actionDataFilter:
+          toStateData: ".infrasWorkflows"
+    transition: QueryWorkflow
+  - name: QueryWorkflow
+    type: foreach
+    inputCollection: "${ .infrasWorkflows }"
+    outputCollection: "${ .fetchResults }"
+    iterationParam: infrasWorkflow
+    actions:
+    - name: checkAction
+      functionRef:
+        refName: checkProcessDefinitionExistence
+        arguments:
+          query: "query CheckProcessDefQuery($id: String) { ProcessDefinitions  ( where: {id: { equal: $id} } ) { id } }"
+          variables: 
+            id: "${ .infrasWorkflow }"
+          operationName: "CheckProcessDefQuery"
+      actionDataFilter:
+        results: "${ .data.ProcessDefinitions[0].id }"
+    transition: Check
+  - name: Check
+    type: switch
+    dataConditions:
+      - condition: (.infrasWorkflows-.fetchResults | length > 0)
+        transition: PrintError
+    defaultCondition:
+      transition: HandleNoError
+  - name: PrintError
+    type: operation
+    actions:
+    - name: error
+      functionRef:
+        refName: logOuput
+        arguments:
+          message: "\"workflows: \\(.infrasWorkflows-.fetchResults) are not found\""
+    stateDataFilter:
+      output: ". += { missingWorkflows: (.infrasWorkflows - .fetchResults) } | del(.infrasWorkflows, .fetchResults)"
+    transition: HandleError
+  - name: HandleError
+    type: operation
+    actions:
+    - name: error
+      functionRef:
+        refName: removeMissingWorkflowsFromOptions
+      actionDataFilter:
+        toStateData: "${ .validatedResult }"
+    stateDataFilter:
+      output: ".originalResult = .result | del(.result)"
+    end: true
+  - name: HandleNoError
+    type: operation
+    actions: []
+    stateDataFilter:
+      output: ".validatedResult = .result | del(.infrasWorkflows, .fetchResults)"
+    end: true

--- a/assessment/src/main/resources/specs/dataindex.yaml
+++ b/assessment/src/main/resources/specs/dataindex.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: The Data Index Graphql API
+  version: 1.0.0-SNAPSHOT
+paths:
+  /graphql:
+    post:
+      operationId: reactiveGraphQLHandlerPost
+      summary: GraphQL
+      description: ""
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GraphQLQuery'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+components:
+  schemas:
+    GraphQLQuery:
+      type: object
+      properties:
+        query:
+          type: string
+        variables:
+          type: object
+        operationName:
+          type: string


### PR DESCRIPTION
[FLPATH-621](https://issues.redhat.com/secure/RapidBoard.jspa?rapidView=16717&projectKey=FLPATH&view=detail&selectedIssue=FLPATH-621) add precheck subflow to assessment

preCheck workflow definition
![Screenshot 2023-11-27 at 9 40 54 AM](https://github.com/parodos-dev/serverless-workflow-examples/assets/58698556/3fcb8fa0-6f0a-4e3f-abc3-4bd5694e877b)

* the input of preCheck is the result workflowOptions from the parent assessment workflow
* data-index is used to validate the existence of workflow options

sample output from preCheck subflow:
```json
{
  "repositoryUrl" : "java",
  "missingWorkflows" : [ "ocpOnbarding", "vmOnboarding" ],
  "validatedResult" : {
    "migrationOptions" : [ {
      "id" : "move2kube",
      "name" : "Move2Kube"
    } ],
    "newOptions" : [ ],
    "otherOptions" : [ {
      "id" : "training",
      "name" : "Training"
    } ],
    "upgradeOptions" : [ ]
  },
  "originalResult" : {
    "currentVersion" : {
      "id" : "ocpOnbarding",
      "name" : "Ocp Onboarding"
    },
    "upgradeOptions" : [ ],
    "migrationOptions" : [ {
      "id" : "move2kube",
      "name" : "Move2Kube"
    } ],
    "newOptions" : [ {
      "id" : "vmOnboarding",
      "name" : "Vm Onboarding"
    } ],
    "continuationOptions" : [ ],
    "otherOptions" : [ {
      "id" : "training",
      "name" : "Training"
    } ]
  }
}
```
