### PR TITLE
FLPATH-861 Promote M2K workflow from examples to prod

### DIFF
--- a/.github/workflows/m2k-func.yaml
+++ b/.github/workflows/m2k-func.yaml
@@ -1,6 +1,7 @@
 name: Build and push MTA-functions container image
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
     paths:

--- a/.github/workflows/m2k-func.yaml
+++ b/.github/workflows/m2k-func.yaml
@@ -23,6 +23,9 @@ jobs:
     - name: Build Java projects
       run: |
         cd ${WORKDIR}
+        cd move2kubeAPI
+        make install
+        cd ..
         mvn ${MVN_OPTS} -B clean package -DskipTests
     - name: Buildah Action
       id: build-image

--- a/.github/workflows/m2k-func.yaml
+++ b/.github/workflows/m2k-func.yaml
@@ -31,14 +31,12 @@ jobs:
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
-        workdir: ${{ env.WORKDIR }}
+        context: ${{ env.WORKDIR }}
         image: serverless-workflow-m2k-kfunc
         tags: latest ${{ github.sha }}
         extra-args: --ulimit nofile=4096:4096
         containerfiles: |
-          src/main/docker/Dockerfile.jvm
-        build-args: |
-          WF_RESOURCES=${{ inputs.workflow_id }}/
+          ${{ env.WORKDIR }}/src/main/docker/Dockerfile.jvm
 
     - name: Push To quay.io
       id: push-to-quay

--- a/.github/workflows/m2k-func.yaml
+++ b/.github/workflows/m2k-func.yaml
@@ -12,7 +12,7 @@ env:
   MVN_OPTS: ""
     
 jobs:
-  build:
+  build-and-push-m2k-func:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -27,6 +27,7 @@ jobs:
         make install
         cd ..
         mvn ${MVN_OPTS} -B clean package -DskipTests
+
     - name: Buildah Action
       id: build-image
       uses: redhat-actions/buildah-build@v2

--- a/.github/workflows/m2k-func.yaml
+++ b/.github/workflows/m2k-func.yaml
@@ -1,0 +1,50 @@
+name: Build and push MTA-functions container image
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'm2k/m2k-func/**'
+
+env:
+  WORKDIR: m2k/m2k-func
+  MVN_OPTS: ""
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Build Java projects
+      run: |
+        cd ${WORKDIR}
+        mvn ${MVN_OPTS} -B clean package -DskipTests
+    - name: Buildah Action
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        workdir: ${{ env.WORKDIR }}
+        image: serverless-workflow-m2k-kfunc
+        tags: latest ${{ github.sha }}
+        extra-args: --ulimit nofile=4096:4096
+        containerfiles: |
+          src/main/docker/Dockerfile.jvm
+        build-args: |
+          WF_RESOURCES=${{ inputs.workflow_id }}/
+
+    - name: Push To quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: quay.io/orchestrator
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
Adding GH action to build and push `m2k-func` functions according to the README file:

```
cd move2kubeAPI
make install
cd ..
mvn clean install
docker build -t quay.io/orchestrator/m2k-kfunc:2.0.0-SNAPSHOT -f src/main/docker/Dockerfile.jvm .
```

Required secrets added to the upstream repo according to the `orchestrator-ci` [robot account](https://quay.io/organization/orchestrator?tab=robots)